### PR TITLE
Add SCP backup strategy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Edge
+
+* Add SCP backup strategy.
+
 ## 0.4.4 - 2023-06-30
 
 * Remove `default_executable` line and simplify executables definition.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     webtranslateit-safe (0.4.4)
       aws-s3
       cloudfiles
+      net-scp
       net-sftp
 
 GEM
@@ -53,6 +54,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     nenv (0.3.0)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.1.0)

--- a/README.markdown
+++ b/README.markdown
@@ -155,6 +155,13 @@ The procedure to create and transfer the key is as follows:
         password "ssh password for sftp"
       end
 
+      sftp do
+        host "sftp.astrails.com"
+        user "astrails"
+        # port 8023
+        password "ssh password for scp"
+      end
+
       gpg do
         command "/usr/local/bin/gpg"
         options  "--no-use-agent"
@@ -170,6 +177,7 @@ The procedure to create and transfer the key is as follows:
         s3 100
         cloudfiles 100
         sftp 100
+        scp 100
       end
 
       mysqldump do

--- a/lib/webtranslateit/safe.rb
+++ b/lib/webtranslateit/safe.rb
@@ -1,6 +1,7 @@
 require 'aws/s3'
 require 'cloudfiles'
 require 'net/sftp'
+require 'net/scp'
 # require 'net/ftp'
 require 'fileutils'
 require 'benchmark'
@@ -31,6 +32,7 @@ require 'webtranslateit/safe/sink'
 require 'webtranslateit/safe/local'
 require 'webtranslateit/safe/s3'
 require 'webtranslateit/safe/cloudfiles'
+require 'webtranslateit/safe/scp'
 require 'webtranslateit/safe/sftp'
 require 'webtranslateit/safe/ftp'
 
@@ -53,7 +55,7 @@ module WebTranslateIt
         next unless collection = config[*path]
 
         collection.each do |name, c|
-          klass.new(name, c).backup.run(c, :gpg, :gzip, :local, :s3, :cloudfiles, :sftp, :ftp)
+          klass.new(name, c).backup.run(c, :gpg, :gzip, :local, :s3, :cloudfiles, :scp, :sftp, :ftp)
         end
       end
 

--- a/lib/webtranslateit/safe/config/builder.rb
+++ b/lib/webtranslateit/safe/config/builder.rb
@@ -77,7 +77,7 @@ module WebTranslateIt
                      :api_key, :container, :socket, :service_net, :repo_path
         multi_value :skip_tables, :exclude, :files
         mixed_value :s3, :local, :cloudfiles, :sftp, :mysqldump, :tar, :gpg, :keep, :pgdump, :tar, :svndump,
-                    :ftp, :mongodump
+                    :ftp, :mongodump, :scp
         collection :database, :archive, :repo
 
         private

--- a/lib/webtranslateit/safe/scp.rb
+++ b/lib/webtranslateit/safe/scp.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module WebTranslateIt
+
+  module Safe
+
+    class Scp < Sink
+
+      MAX_RETRIES = 5
+
+      protected
+
+      def active?
+        host && user
+      end
+
+      def path
+        @path ||= expand(config[:scp, :path] || config[:local, :path] || ':kind/:id')
+      end
+
+      def save # rubocop:todo Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        raise 'pipe-streaming not supported for SCP.' unless @backup.path
+
+        puts "Uploading #{host}:#{full_path} via SCP" if verbose? || dry_run?
+
+        return if dry_run? || local_only?
+
+        retries = 0
+        opts = {}
+        opts[:password] = password if password
+        opts[:port] = port if port
+        Net::SCP.start(host, user, opts) do |scp|
+          puts "Sending #{@backup.path} to #{full_path}" if verbose?
+          begin
+            scp.upload! @backup.path, full_path
+          rescue IO::TimeoutError
+            puts 'Upload timed out, retrying'
+            retries += 1
+            if retries >= MAX_RETRIES
+              puts "Tried #{retries} times. Giving up."
+            else
+              retry unless retries >= MAX_RETRIES
+            end
+          rescue Net::SCP::Error
+            puts "Ensuring remote path (#{path}) exists" if verbose?
+            # mkdir -p
+            folders = path.split('/')
+            folders.each_index do |i|
+              folder = folders[0..i].join('/')
+              puts "Creating #{folder} on remote" if verbose?
+              begin
+                scp.mkdir!(folder)
+              rescue StandardError
+                Net::SCP::Error
+              end
+            end
+            retry
+          end
+        end
+        puts '...done' if verbose?
+      end
+
+      def cleanup
+        return if local_only? || dry_run?
+
+        return unless (keep = config[:keep, :scp])
+
+        puts "listing files: #{host}:#{base}*" if verbose?
+        opts = {}
+        opts[:password] = password if password
+        opts[:port] = port if port
+        Net::SFTP.start(host, user, opts) do |sftp|
+          files = sftp.dir.glob(path, File.basename("#{base}*"))
+
+          puts files.collect(&:name) if verbose?
+
+          files = files.collect(&:name).sort
+
+          cleanup_with_limit(files, keep) do |f|
+            file = File.join(path, f)
+            puts "removing sftp file #{host}:#{file}" if dry_run? || verbose?
+            sftp.remove!(file) unless dry_run? || local_only?
+          end
+        end
+      end
+
+      def host
+        config[:scp, :host]
+      end
+
+      def user
+        config[:scp, :user]
+      end
+
+      def password
+        config[:scp, :password]
+      end
+
+      def port
+        config[:scp, :port]
+      end
+
+    end
+
+  end
+
+end

--- a/templates/script.rb
+++ b/templates/script.rb
@@ -54,6 +54,15 @@ safe do
   #   path ":kind/:id" # this is the default
   # end
 
+  ## uncomment to enable uploads via SCP
+  # scp do
+  #   host "YOUR_REMOTE_HOSTNAME"
+  #   user "YOUR_REMOTE_USERNAME"
+  #   # port "NON STANDARD SSH PORT"
+  #   password "YOUR_REMOTE_PASSWORD"
+  #   path ":kind/:id" # this is the default
+  # end
+
   ## uncomment to enable uploads via FTP
   # ftp do
   #   host "YOUR_REMOTE_HOSTNAME"

--- a/webtranslateit-safe.gemspec
+++ b/webtranslateit-safe.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-s3'
   spec.add_dependency 'cloudfiles'
+  spec.add_dependency 'net-scp'
   spec.add_dependency 'net-sftp'
 
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
This is essentially a clone of the SFTP strategy, but transfer protocol is faster for larger files. Since SCP doesn't implement deleting files, file cleanup is done with SFTP.