### PR TITLE
Use pigz instead of gzip when available

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+## Edge
+
+* Use pigz instead of gzip when available on system to speed up compression time. 
 ## 0.4.8 - 2023-07-05
 
 * Remove svndump feature.

--- a/lib/web_translate_it/safe.rb
+++ b/lib/web_translate_it/safe.rb
@@ -5,8 +5,8 @@ require 'net/scp'
 require 'tmpdir'
 require 'fileutils'
 require 'benchmark'
-
 require 'tempfile'
+require 'mkmf'
 
 require 'web_translate_it/safe/tmp_file'
 
@@ -26,12 +26,18 @@ require 'web_translate_it/safe/mongodump'
 require 'web_translate_it/safe/pipe'
 require 'web_translate_it/safe/gpg'
 require 'web_translate_it/safe/gzip'
+require 'web_translate_it/safe/pigz'
 
 require 'web_translate_it/safe/sink'
 require 'web_translate_it/safe/local'
 require 'web_translate_it/safe/s3'
 require 'web_translate_it/safe/cloudfiles'
 require 'web_translate_it/safe/sftp'
+
+# Keeps mkmf from littering STDOUT
+MakeMakefile::Logging.quiet = true
+# Keeps mkmf from creating a mkmf.log file on current path
+MakeMakefile::Logging.logfile(File::NULL)
 
 module WebTranslateIt
 
@@ -51,7 +57,7 @@ module WebTranslateIt
         next unless collection = config[*path]
 
         collection.each do |name, c|
-          klass.new(name, c).backup.run(c, :gpg, :gzip, :local, :s3, :cloudfiles, :sftp)
+          klass.new(name, c).backup.run(c, :gpg, :pigz, :gzip, :local, :s3, :cloudfiles, :sftp)
         end
       end
 

--- a/lib/web_translate_it/safe/pigz.rb
+++ b/lib/web_translate_it/safe/pigz.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module WebTranslateIt
+
+  module Safe
+
+    class Pigz < Pipe
+
+      protected
+
+      def post_process
+        @backup.compressed = true
+      end
+
+      def pipe
+        '|pigz'
+      end
+
+      def extension
+        '.gz'
+      end
+
+      def active?
+        !@backup.compressed && !(find_executable 'pigz').nil?
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
It speeds up compression dramatically.

With gzip:

```
~/Desktop% webtranslateit-safe server.rb -v
checking for pigz... no
command: tar -cf - -h  /Users/edouard/code/webtranslateit.com|gzip
tar: Removing leading '/' from member names
command took 12.58 second(s).
```

With pigz:

```
~/Desktop% webtranslateit-safe server.rb -v
checking for pigz... yes
command: tar -cf - -h  /Users/edouard/code/webtranslateit.com|pigz
tar: Removing leading '/' from member names
command took 4.77 second(s).
```